### PR TITLE
Fix branching and introduce an argument

### DIFF
--- a/fuzzel-emoji
+++ b/fuzzel-emoji
@@ -1,4 +1,5 @@
 #!/bin/bash
+wtype 0
 if [ $? -eq 0 ]
 then
     sed '1,/^### DATA ###$/d' $0 | fuzzel --no-fuzzy --icon-theme=candy-icons --background-color=1A1513dd --text-color=F8D4D2ff --match-color=FFB3B1ff --border-width=2 --border-radius=15 --border-color=EB8A89ff	 --selection-color=585b70ff --selection-text-color=F8D4D2ff --selection-match-color=FFB3B1ff --font="Lexend"  --prompt=">>  " --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wtype -

--- a/fuzzel-emoji
+++ b/fuzzel-emoji
@@ -1,11 +1,27 @@
 #!/bin/bash
-wtype 0
-if [ $? -eq 0 ]
-then
-    sed '1,/^### DATA ###$/d' $0 | fuzzel --no-fuzzy --icon-theme=candy-icons --background-color=1A1513dd --text-color=F8D4D2ff --match-color=FFB3B1ff --border-width=2 --border-radius=15 --border-color=EB8A89ff	 --selection-color=585b70ff --selection-text-color=F8D4D2ff --selection-match-color=FFB3B1ff --font="Lexend"  --prompt=">>  " --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wtype -
-else
-    sed '1,/^### DATA ###$/d' $0 | fuzzel --no-fuzzy --icon-theme=candy-icons --background-color=1A1513dd --text-color=F8D4D2ff --match-color=FFB3B1ff --border-width=2 --border-radius=15 --border-color=EB8A89ff	 --selection-color=585b70ff --selection-text-color=F8D4D2ff --selection-match-color=FFB3B1ff --font="Lexend"  --prompt=">>  " --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
-fi
+set -euo pipefail
+
+MODE="${1:-type}"
+
+emoji="$(sed '1,/^### DATA ###$/d' "$0" | fuzzel --no-fuzzy --icon-theme=candy-icons --background-color=1A1513dd --text-color=F8D4D2ff --match-color=FFB3B1ff --border-width=2 --border-radius=15 --border-color=EB8A89ff --selection-color=585b70ff --selection-text-color=F8D4D2ff --selection-match-color=FFB3B1ff --font="Lexend" --prompt=">>  " --dmenu | cut -d ' ' -f 1 | tr -d '\n')"
+
+case "$MODE" in
+    type)
+        wtype "${emoji}" || wl-copy "${emoji}"
+        ;;
+    copy)
+        wl-copy "${emoji}"
+        ;;
+    both)
+        wtype "${emoji}" || true
+        wl-copy "${emoji}"
+        ;;
+    *)
+        echo "Usage: $0 [type|copy|both]"
+        exit 1
+        ;;
+esac
+
 exit
 ### DATA ###
 😀 grinning face face smile happy joy :D grin


### PR DESCRIPTION
At first I wanted to fix the branching (there was a missing `wtype 0` before the `if` meaning we always took the first branch, see [wofi code](https://github.com/dln/wofi-emoji/blob/d73ed5e48660ae4d02ea5ff53c4cc1b64b6deb9f/wofi-emoji#L2)).

But then I realized I want to be able to use both type and copy (because sometimes the typing just doesn't work, and then it's handy to have the emoji in clipboard.) So I added an argument to control the behaviour. Still uses typing with copy fallback as the default.